### PR TITLE
Fix minor details in project_wip_material

### DIFF
--- a/project_wip_material/i18n/fr.po
+++ b/project_wip_material/i18n/fr.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 11.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-22 16:33+0000\n"
-"PO-Revision-Date: 2019-03-22 12:34-0400\n"
+"POT-Creation-Date: 2019-04-03 16:39+0000\n"
+"PO-Revision-Date: 2019-04-03 12:39-0400\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "Language: fr\n"
@@ -53,6 +53,7 @@ msgstr "Quantités consommées"
 #. module: project_wip_material
 #: code:addons/project_wip_material/consumption_route.py:96
 #: model:ir.ui.view,arch_db:project_wip_material.task_form_with_material
+#: model:ir.ui.view,arch_db:project_wip_material.task_form_with_picking_smart_button
 #: model:ir.ui.view,arch_db:project_wip_material.warehouse_form_with_consumption_steps
 #, python-format
 msgid "Consumption"
@@ -62,6 +63,13 @@ msgstr "Consommation"
 #: model:ir.model.fields,field_description:project_wip_material.field_stock_warehouse_consu_location_id
 msgid "Consumption Location"
 msgstr "Emplacement de consommation"
+
+#. module: project_wip_material
+#: model:ir.model.fields,field_description:project_wip_material.field_project_task_consumption_picking_count
+#, fuzzy
+#| msgid "Consumption Picking Type"
+msgid "Consumption Picking Count"
+msgstr "Nombre d'opérations de consommation"
 
 #. module: project_wip_material
 #: model:ir.model.fields,field_description:project_wip_material.field_stock_warehouse_consu_type_id
@@ -183,12 +191,7 @@ msgstr ""
 "initiale inférieure à zéro. La ligne {line} a une quantité de {qty}."
 
 #. module: project_wip_material
-#: model:ir.model.fields,field_description:project_wip_material.field_project_task_picking_count
-msgid "Picking Count"
-msgstr "Nombre de pickings"
-
-#. module: project_wip_material
-#: model:ir.model.fields,field_description:project_wip_material.field_project_task_picking_ids
+#: model:ir.model.fields,field_description:project_wip_material.field_project_task_consumption_picking_ids
 msgid "Pickings"
 msgstr "Pickings"
 
@@ -236,11 +239,6 @@ msgid "Stock Moves"
 msgstr "Mouvements d'inventaire"
 
 #. module: project_wip_material
-#: model:ir.ui.view,arch_db:project_wip_material.task_form_with_picking_smart_button
-msgid "Stock Picking"
-msgstr "Stock Picking"
-
-#. module: project_wip_material
 #: model:ir.model,name:project_wip_material.model_project_task
 #: model:ir.model.fields,field_description:project_wip_material.field_procurement_group_task_id
 #: model:ir.model.fields,field_description:project_wip_material.field_project_task_material_task_id
@@ -255,7 +253,7 @@ msgid "Task Material Consumption"
 msgstr "Consommation matériel sur tâche"
 
 #. module: project_wip_material
-#: code:addons/project_wip_material/task_material.py:332
+#: code:addons/project_wip_material/task_material.py:333
 #, python-format
 msgid ""
 "The material line {line} can not be deleted because it is bound to stock "
@@ -270,18 +268,18 @@ msgid "The operation type determines the picking view"
 msgstr ""
 
 #. module: project_wip_material
-#: code:addons/project_wip_material/task_material.py:252
+#: code:addons/project_wip_material/task_material.py:253
 #, python-format
 msgid ""
 "The quantity on the material line {line} can not be reduced to "
 "{new_quantity} (it can not be lower than the delivered quantity).\n"
 "\n"
-"The line may only be reduced to a minimum {minimum_qty} {uom}."
+"The line may not be reduced below a minimum of {minimum_qty} {uom}."
 msgstr ""
 "La quantité sur la ligne de matériel {line} ne peut pas être réduite à "
 "{new_quantity} (elle ne peut pas être plus petite que la quantité livrée).\n"
 "\n"
-"La ligne peut seulement être réduite à un minimum de {minimum_qty} {uom}."
+"La ligne ne peut pas être réduite en dessous de {minimum_qty} {uom}."
 
 #. module: project_wip_material
 #: code:addons/project_wip_material/wip_journal_entries.py:39
@@ -337,7 +335,7 @@ msgid "Warehouse"
 msgstr "Entrepôt"
 
 #. module: project_wip_material
-#: code:addons/project_wip_material/task_material.py:314
+#: code:addons/project_wip_material/task_material.py:315
 #, python-format
 msgid ""
 "You may not change the product on an existing material line. Instead of "

--- a/project_wip_material/task_material.py
+++ b/project_wip_material/task_material.py
@@ -220,6 +220,7 @@ class TaskMaterialLine(models.Model):
 
         if move_will_be_empty:
             move._action_cancel()
+            move.picking_id = False
         else:
             move.product_uom_qty -= reduced_qty
 
@@ -252,11 +253,11 @@ class TaskMaterialLine(models.Model):
             raise ValidationError(_(
                 'The quantity on the material line {line} can not be reduced to {new_quantity} '
                 '(it can not be lower than the delivered quantity).\n\n'
-                'The line may only be reduced to a minimum {minimum_qty} {uom}.'
+                'The line may not be reduced below a minimum of {minimum_qty} {uom}.'
             ).format(
                 line=self.product_id.display_name,
                 new_quantity=self.initial_qty,
-                minimum_qty=reducible_qty,
+                minimum_qty=total_move_qty - reducible_qty,
                 uom=self.product_uom_id.name,
             ))
 

--- a/project_wip_material/task_picking_smart_button.py
+++ b/project_wip_material/task_picking_smart_button.py
@@ -9,8 +9,8 @@ class Task(models.Model):
 
     _inherit = 'project.task'
 
-    picking_count = fields.Integer(compute='_compute_consumption_pickings')
-    picking_ids = fields.One2many(
+    consumption_picking_count = fields.Integer(compute='_compute_consumption_pickings')
+    consumption_picking_ids = fields.One2many(
         'stock.picking', string='Pickings',
         compute='_compute_consumption_pickings')
 
@@ -19,11 +19,12 @@ class Task(models.Model):
         for task in tasks_with_procurement_group:
             pickings = self.env['stock.picking'].search([
                 ('group_id', '=', task.procurement_group_id.id),
+                ('picking_type_code', 'in', ('consumption', 'consumption_return')),
             ])
-            task.picking_ids = pickings
-            task.picking_count = len(pickings)
+            task.consumption_picking_ids = pickings
+            task.consumption_picking_count = len(pickings)
 
-    def open_picking_view_from_task(self):
+    def open_consumption_picking_view_from_task(self):
         """Open the view of stock pickings related to the task.
 
         If there are multiple pickings, open the list view.
@@ -36,12 +37,12 @@ class Task(models.Model):
         """
         action = self.env.ref('stock.action_picking_tree_all').read()[0]
 
-        if self.picking_count > 1:
-            action['domain'] = [('id', 'in', self.picking_ids.ids)]
+        if self.consumption_picking_count > 1:
+            action['domain'] = [('id', 'in', self.consumption_picking_ids.ids)]
 
         else:
             picking_form_view = self.env.ref('stock.view_picking_form')
             action['views'] = [(picking_form_view.id, 'form')]
-            action['res_id'] = self.picking_ids.id
+            action['res_id'] = self.consumption_picking_ids.id
 
         return action

--- a/project_wip_material/tests/test_task_material.py
+++ b/project_wip_material/tests/test_task_material.py
@@ -92,6 +92,12 @@ class TestGenerateProcurementsFromTask(TaskMaterialCase):
         line.initial_qty = 0
         assert line.move_ids.state == 'cancel'
 
+    def test_if_delete_material_line__move_removed_from_stock_picking(self):
+        line = self._create_material_line(initial_qty=10)
+        line.initial_qty = 0
+        assert line.move_ids
+        assert not line.move_ids.picking_id
+
     def test_if_raise_initial_quantity__stock_move_is_increased(self):
         line = self._create_material_line(initial_qty=10)
         line.initial_qty = 20

--- a/project_wip_material/views/task_picking_smart_button.xml
+++ b/project_wip_material/views/task_picking_smart_button.xml
@@ -8,12 +8,12 @@
         <field name="arch" type="xml">
             <button name="toggle_active" position="before">
                  <button
-                    name="open_picking_view_from_task" type="object" class="oe_stat_button"
+                    name="open_consumption_picking_view_from_task" type="object" class="oe_stat_button"
                     icon="fa-truck"
                     groups="stock.group_stock_user"
-                    attrs="{'invisible': [('picking_count', '=', 0)]}"
+                    attrs="{'invisible': [('consumption_picking_count', '=', 0)]}"
                     >
-                        <field name="picking_count" widget="statinfo" string="Stock Picking"/>
+                        <field name="consumption_picking_count" widget="statinfo" string="Consumption"/>
                 </button>
             </button>
         </field>


### PR DESCRIPTION
Rename the smart button on task to .
The button now only points to consumption pickings.

Fix the error message when reducing a material line below the quantity delivered.

Remove cancelled material move lines from stock pickings.
Otherwise, a the backorder confirmation appears when confirming the picking.