### PR TITLE
Fix propagation of deadline from project to task

### DIFF
--- a/project_task_deadline_from_project/models/project_task.py
+++ b/project_task_deadline_from_project/models/project_task.py
@@ -11,21 +11,19 @@ class ProjectTaskWithDeadlineFromProject(models.Model):
 
     @api.model
     def create(self, vals):
-        should_propagate_deadline = vals.get('project_id') and 'date_deadline' not in vals
+        task = super().create(vals)
+        should_propagate_deadline = task.project_id and 'date_deadline' not in vals
         if should_propagate_deadline:
-            vals['date_deadline'] = self._get_deadline_from_project_id(vals['project_id'])
-        return super().create(vals)
+            task.date_deadline = task.project_id.date
+        return task
 
     @api.multi
     def write(self, vals):
         should_propagate_deadline = vals.get('project_id') and 'date_deadline' not in vals
         if should_propagate_deadline:
-            vals['date_deadline'] = self._get_deadline_from_project_id(vals['project_id'])
+            project = self.env['project.project'].browse(vals['project_id'])
+            vals['date_deadline'] = project.date
         return super().write(vals)
-
-    def _get_deadline_from_project_id(self, project_id):
-        project = self.env['project.project'].browse(project_id)
-        return project.date
 
     @api.onchange('project_id')
     def _onchange_project_propagate_deadline(self):

--- a/project_task_deadline_from_project/tests/test_project_task.py
+++ b/project_task_deadline_from_project/tests/test_project_task.py
@@ -28,6 +28,11 @@ class TestProjectTask(common.SavepointCase):
         })
         self.assertEqual(task.date_deadline, self.deadline)
 
+    def test_when_creating_task_with_default_project_then_deadline_is_propagated(self):
+        task = self.env['project.task'].with_context(
+            default_project_id=self.project_with_deadline.id).create({'name': 'Task 2'})
+        self.assertEqual(task.date_deadline, self.deadline)
+
     def test_when_creating_task_if_project_has_no_deadline_then_deadline_is_empty(self):
         task = self.env['project.task'].create({
             'name': 'Task 2',


### PR DESCRIPTION
When the task is created from the kanban view, the project_id is passed in context
instead of vals.

https://isidor.numigi.net/web#id=11485&model=project.task&view_type=form&menu_id=