### PR TITLE
Fix minor issues with project_remaining_hours_update

### DIFF
--- a/project_remaining_hours_update/views/project_task.xml
+++ b/project_remaining_hours_update/views/project_task.xml
@@ -48,4 +48,19 @@
         </field>
     </record>
 
+    <record id="task_form_with_remaining_hours_field" model="ir.ui.view">
+        <field name="name">Task Form: add remaining hours field (invisible)</field>
+        <field name="model">project.task</field>
+        <field name="inherit_id" ref="hr_timesheet.view_task_form2_inherited"/>
+        <field name="arch" type="xml">
+            <form position="inside">
+                <!--
+                    This field is necessary, because otherwise, when an onchange is triggered,
+                    the computation of remaining_hours ignores remaining_hours_ids.
+                -->
+                <field name="remaining_hours_ids" invisible="1"/>
+            </form>
+        </field>
+    </record>
+
 </odoo>

--- a/project_remaining_hours_update/wizard/project_task_remaining_hours_update.xml
+++ b/project_remaining_hours_update/wizard/project_task_remaining_hours_update.xml
@@ -9,7 +9,7 @@
                 <sheet>
                     <group>
                         <field name="task_id" readonly="1"/>
-                        <field name="new_remaining_hours" required="1"/>
+                        <field name="new_remaining_hours" widget="float_time" required="1"/>
                         <field name="comment"/>
                     </group>
                 </sheet>


### PR DESCRIPTION
Show the remaining hours field in the wizard as float_time.
Fix the computation of remaining hours when ran in onchange.