### PR TITLE
Prevent wrong ui manipulations with existing task links

### DIFF
--- a/project_task_link/__manifest__.py
+++ b/project_task_link/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     'name': 'Project Task Link',
-    'version': '1.1.0',
+    'version': '1.1.1',
     'author': 'Numigi',
     'maintainer': 'Numigi',
     'website': 'https://bit.ly/numigi-com',

--- a/project_task_link/models/common.py
+++ b/project_task_link/models/common.py
@@ -11,8 +11,14 @@ def _find_task_references(env: 'Environment', text: str) -> List[TaskReference]:
 
 
 def _convert_text_to_html_with_task_links(env: 'Environment', text: str) -> str:
+    """Convert the given text into HTML containing task links.
+
+    The &#8291; character is an invisible separator.
+    It prevents a user (with large fingers) from inserting text inside an
+    existing link by accident.
+    """
     for reference in _find_task_references(env, text):
-        link = "<a href=\"{url}\" target=\"_blank\">{ref}</a>".format(
+        link = "&#8291;<a href=\"{url}\" target=\"_blank\">{ref}</a>&#8291;".format(
             url=reference.task.get_portal_access_url(),
             ref=reference.normalized_string,
         )

--- a/project_task_link/tests/test_project_task.py
+++ b/project_task_link/tests/test_project_task.py
@@ -14,12 +14,20 @@ class TestProjectTask(common.SavepointCase):
         super().setUpClass()
 
         cls.task = cls.env['project.task'].create({'name': 'My Task'})
-        cls.referenced_task = cls.env['project.task'].create({'name': 'Some Other Task'})
+        cls.referenced_task = cls.env['project.task'].create({'name': 'Some Referenced Task'})
         cls.referenced_task_url = cls.referenced_task.get_portal_access_url()
         cls.task_ref = "TA#{}".format(cls.referenced_task.id)
         cls.task_link = "<a href=\"{url}\" target=\"_blank\">{task_ref}</a>".format(
             url=cls.referenced_task_url,
             task_ref=cls.task_ref,
+        )
+
+        cls.referenced_task_2 = cls.env['project.task'].create({'name': 'Some Other Task'})
+        cls.referenced_task_url_2 = cls.referenced_task_2.get_portal_access_url()
+        cls.task_ref_2 = "TA#{}".format(cls.referenced_task_2.id)
+        cls.task_link_2 = "<a href=\"{url}\" target=\"_blank\">{task_ref}</a>".format(
+            url=cls.referenced_task_url_2,
+            task_ref=cls.task_ref_2,
         )
 
         cls.base_url = cls.env['ir.config_parameter'].get_param('web.base.url')
@@ -63,6 +71,20 @@ class TestProjectTask(common.SavepointCase):
     def test_if_task_ref_inside_link_node__no_link_node_added(self, description):
         self.task.write({'description': description.format(task_ref=self.task_ref)})
         assert self.task_link not in self.task.description
+
+    @data(
+        "{task_ref}{task_ref_2}",
+        "{task_ref}<br>{task_ref_2}",
+    )
+    def test_two_task_refs_in_same_descriptions(self, description):
+        self.task.write({
+            'description': description.format(
+                task_ref=self.task_ref,
+                task_ref_2=self.task_ref_2,
+            ),
+        })
+        assert self.task_link in self.task.description
+        assert self.task_link_2 in self.task.description
 
     @data(
         "TA{}",


### PR DESCRIPTION
Add special characters around the task ref node. This way if the user inserts his cursor before
or after the link, by default, the cursor will be placed outside the link.