### PR TITLE
TA#16896 Display the partner from the account move

### DIFF
--- a/project_cost_report/report.xml
+++ b/project_cost_report/report.xml
@@ -12,7 +12,7 @@
                 <span t-field="line.name"/>
             </td>
             <td>
-                <span t-if="is_outsourcing_line(line)" t-field="line.partner_id.display_name"/>
+                <span t-if="is_outsourcing_line(line)" t-field="line.move_id.partner_id.display_name"/>
             </td>
             <td>
                 <span t-field="line.employee_id.name"/>


### PR DESCRIPTION
The supplier is not propagated to the analytic line.
The analytic line always contain the customer.

To get the supplier from an outsourcing analytic line, it is necessary to
drilldown to the account move.