### PR TITLE
TA#17709 Fix cost report dates

### DIFF
--- a/project_cost_report/report.xml
+++ b/project_cost_report/report.xml
@@ -6,7 +6,7 @@
         <tr class="o_project_cost_report__level_3 o_project_cost_report__analytic_line" t-att-data-id="line.id">
             <td></td>
             <td>
-                <span t-field="line.date"/>
+                <span t-field="line.date" style="white-space: nowrap; margin-right: 8px;"/>
             </td>
             <td>
                 <span t-field="line.name"/>


### PR DESCRIPTION
Prevent the date from wrapping around.
Force a margin between the date and the line description.