### PR TITLE
TA#27486 filter on projects with no parent

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,18 +1,27 @@
+version: 2.0
+
+quay_io_login: &quay_io_login
+  name: Login to Quay.io register
+  command: docker login quay.io -u "${QUAY_USER}" -p "${QUAY_TOKEN}"
+
 jobs:
   tests:
     machine: true
     steps:
-      - checkout
+       - checkout
 
-      - run:
+       - run:
+           <<: *quay_io_login
+
+       - run:
           name: Build -- Init Database
           command: docker-compose run --rm odoo odoo --stop-after-init -i main
 
-      - run:
+       - run:
           name: Setup Log Folder For Reports
           command: sudo mkdir -p .log && sudo chmod 777 .log
 
-      - run:
+       - run:
           name: Run Test
           command: docker-compose run --rm odoo run_pytest.sh
 
@@ -20,21 +29,8 @@ jobs:
           name: Codacy Coverage
           command: bash <(curl -Ls https://coverage.codacy.com/get.sh) report -l python -r .log/coverage.xml
 
-      - store_test_results:
+       - store_test_results:
           path: .log
-
-  testcafe:
-    machine: true
-    steps:
-    - checkout
-
-    - run:
-          name: Build -- Init Database
-          command: docker-compose run --rm odoo odoo --stop-after-init -i main
-
-    - run:
-        name: Run Tests With Chrome
-        command: docker-compose run --rm testcafe 'chrome:headless --no-sandbox' /tests/*.js --skip-js-errors --speed 0.5
 
   # job that find the next tag for the current branch/repo and push the tag to github.
   # it will trigger the publish of a new docker image.
@@ -42,6 +38,8 @@ jobs:
     machine: true
     steps:
       - checkout
+      - run:
+          <<: *quay_io_login
       - run:
           name: Get nws
           command: |
@@ -52,18 +50,17 @@ jobs:
           command: |
             ./nws circleci create-tag -t odoo-base
 
-
 workflows:
   version: 2
   odoo:
     jobs:
-      - tests
-      - testcafe
+      - tests:
+          context: quay.io
+
       - auto-tag:
           context: nws
           requires:
             - tests
-            - testcafe
           filters:
             branches:
               only: /^1\d\.0/

--- a/project_iteration_parent_only/project_project_views.xml
+++ b/project_iteration_parent_only/project_project_views.xml
@@ -7,7 +7,7 @@
         <field name="inherit_id" ref="project_iteration.project_form_with_parent"/>
         <field name="arch" type="xml">
             <field name="parent_id" position="attributes">
-                <attribute name="domain">[("is_parent", "=", True)]</attribute>
+                <attribute name="domain">[("parent_id", "=", False)]</attribute>
             </field>
         </field>
     </record>


### PR DESCRIPTION
Before this commit, the domain excludes non-parent projects (projects without children projects).
The problem is that you may not select a project if it does not have a child already.

After this commit, we exclude projects that are children of other projects.