### PR TITLE
TA#65860 [FIX] project_material: Access to window's action

### DIFF
--- a/project_material/models/project_task.py
+++ b/project_material/models/project_task.py
@@ -175,7 +175,7 @@ class TaskWithMaterialLines(models.Model):
         This method is intended to be inherited to show the list/form view
         of different types of picking related to the task.
         """
-        action = self.env.ref("stock.action_picking_tree_all").read()[0]
+        action = self.env.ref("stock.action_picking_tree_all").sudo().read()[0]
 
         if len(pickings) > 1:
             action["domain"] = [("id", "in", pickings.ids)]


### PR DESCRIPTION
A normal user doesn't have access to read from ir.actions.act_windows, we need to force read with sudo()
This is new in V14. 